### PR TITLE
UI - Edit cases, New cases and cases listing page header section

### DIFF
--- a/DreamInventory.Android/Resources/Resource.designer.cs
+++ b/DreamInventory.Android/Resources/Resource.designer.cs
@@ -15,7 +15,7 @@ namespace DreamInventory.Droid
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/DreamInventory/App.xaml
+++ b/DreamInventory/App.xaml
@@ -30,6 +30,7 @@
             <Style x:Key="MobileListHeaderStyles" TargetType="Label">
                 <Setter Property="TextColor" Value="White" />
                 <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="HorizontalTextAlignment" Value="Center" />
             </Style>
 
             <!--Desktop List Content Styles-->

--- a/DreamInventory/App.xaml
+++ b/DreamInventory/App.xaml
@@ -45,6 +45,12 @@
                 <Setter Property="FontAttributes" Value="Bold" />
             </Style>
 
+            <!--Form Field and Label Styles-->
+            <Style x:Key="FormFieldAndLableStyles" TargetType="Entry">
+                <Setter Property="PlaceholderColor" Value="{StaticResource PrimaryBlack}" />
+                <Setter Property="TextColor" Value="{StaticResource PrimaryBlack}" />
+            </Style>
+
             <OnPlatform x:Key="FontAwesomeBrands" x:TypeArguments="x:String">
                 <On Platform="Android" Value="FontAwesome5Brands.otf#Regular" />
                 <On Platform="iOS" Value="FontAwesome5Brands-Regular" />

--- a/DreamInventory/MasterPage.xaml
+++ b/DreamInventory/MasterPage.xaml
@@ -43,7 +43,42 @@
                     </StackLayout>
                     
                     <Grid Grid.Row="1" Padding="15, 0, 0, 0" Grid.Column="0">
-                        <Grid>
+                        <Grid x:Name="DesktopMenu">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="40" />
+                                <RowDefinition Height="40" />
+                                <RowDefinition Height="40" />
+                            </Grid.RowDefinitions>
+                            <StackLayout Grid.Row="0">
+                                <Label Text="Cases" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Tapped="Cases_Tapped"
+                                            NumberOfTapsRequired="1" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                            </StackLayout>
+                            <StackLayout Grid.Row="1">
+                                <Label Text="Defendants" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Tapped="Defendants_Tapped"
+                                            NumberOfTapsRequired="1" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                            </StackLayout>
+                            <StackLayout Grid.Row="2">
+                                <Label Text="Plaintiffs" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5">
+                                    <Label.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Tapped="Plaintiffs_Tapped"
+                                            NumberOfTapsRequired="1" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                            </StackLayout>
+                        </Grid>
+
+                        <Grid x:Name="MobileMenu">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="40" />
                                 <RowDefinition Height="40" />
@@ -77,7 +112,6 @@
                                 </Label>
                             </StackLayout>
                         </Grid>
-                      
                     </Grid>
 
                 </Grid>

--- a/DreamInventory/MasterPage.xaml.cs
+++ b/DreamInventory/MasterPage.xaml.cs
@@ -15,6 +15,17 @@ namespace DreamInventory
             InitializeComponent();
 
             Detail = new NavigationPage(new CasesPage());
+
+            if (Device.RuntimePlatform == Device.macOS)
+            {
+                MobileMenu.IsVisible = false;
+                DesktopMenu.IsVisible = true;
+            }
+            else
+            {
+                MobileMenu.IsVisible = true;
+                DesktopMenu.IsVisible = false;
+            }
         }
 
         void Cases_Tapped(object sender, EventArgs e)

--- a/DreamInventory/Views/Case/CasesPage.xaml
+++ b/DreamInventory/Views/Case/CasesPage.xaml
@@ -13,56 +13,101 @@
         </StackLayout.Margin>
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="160" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0" x:Name="DesktopHeaderBar" IsVisible="False">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="40" />
+                    <RowDefinition Height="40" />
+                    <RowDefinition Height="40" />
+                </Grid.RowDefinitions>
 
-                <Grid Grid.Column="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                    <StackLayout Grid.Row="0">
+                    <StackLayout Grid.Column="0" VerticalOptions="Center">
                         <Label x:Name="CasesCountDesktop" FontAttributes="Bold" FontSize="Large"/>
                     </StackLayout>
 
-                    <StackLayout Grid.Row="1">
-                        <Label Text="+ Add Case" TextColor="#147efb" FontAttributes="Bold" >
+                    <StackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center">
+                        <Entry Placeholder="Search"
+                               TextColor="{StaticResource PrimaryBlack}"
+                               WidthRequest="250"
+                               HeightRequest="30"
+                               FontSize="14"
+                               Completed="search_event" />
+                    </StackLayout>
+                </Grid>
+
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackLayout Grid.Column="0" HorizontalOptions="Start" VerticalOptions="Center">
+                        <Label Text="+ Add Case" TextColor="#147efb" FontSize="14" FontAttributes="Bold" >
                             <Label.GestureRecognizers>
                                 <TapGestureRecognizer Tapped="NewCase_Tapped" />
                             </Label.GestureRecognizers>
                         </Label>
                     </StackLayout>
+
+                    <StackLayout Grid.Column="1" HorizontalOptions="End" VerticalOptions="Center">
+                        <Picker x:Name="macPicker"
+                                Title="Sort"
+                                WidthRequest="250"
+                                HeightRequest="30"
+                                SelectedIndexChanged="SortPicker_SelectedIndexChanged"
+                                TextColor="{StaticResource PrimaryBlack}"
+                                TitleColor="{StaticResource PrimaryBlack}" />
+                    </StackLayout>
                 </Grid>
 
-                <Grid Grid.Column="1">
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-
-                    <StackLayout Grid.Row="1" HorizontalOptions="End" Padding="30, 0">
-                        <Entry Placeholder="Search" WidthRequest="200" HeightRequest="30" Completed="search_event"/>
-                    </StackLayout>
-                    <StackLayout Orientation="Horizontal" Grid.Row="2" HorizontalOptions="End" Padding="30, 0">
-                        <Button Text="Previous" x:Name="previousButton" HorizontalOptions="Start" Clicked="PreviousButton_Clicked"/>                  
-                        <Button Text="Next" x:Name="nextButton" HorizontalOptions="End" Clicked="NextButton_Clicked"/>
-                        <Picker x:Name="macPicker" Title="Sort" SelectedIndexChanged="SortPicker_SelectedIndexChanged" />
-                    </StackLayout>
+                <Grid Grid.Row="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="260" />
+                    </Grid.ColumnDefinitions>
+                    <Grid Grid.Column="3" Margin="0, 0, 0, 0">
+                        <Button Text="&lt;&lt; Previous"
+                                x:Name="previousButton"
+                                WidthRequest="100"
+                                HorizontalOptions="Start"
+                                Clicked="PreviousButton_Clicked"
+                                TextColor="#147efb"
+                                FontSize="14"
+                                FontAttributes="Bold"
+                                CornerRadius="5"
+                                BackgroundColor="White"
+                                BorderWidth="2"
+                                BorderColor="White" />
+                        <Button Text="Next >>"
+                                x:Name="nextButton"
+                                WidthRequest="70"
+                                HorizontalOptions="End"
+                                Clicked="NextButton_Clicked"
+                                TextColor="#147efb"
+                                FontSize="14"
+                                FontAttributes="Bold"
+                                CornerRadius="5"
+                                BackgroundColor="White"
+                                BorderWidth="2"
+                                BorderColor="White" />
+                    </Grid>
                 </Grid>
             </Grid>
 
-            <Grid Grid.Row="0" x:Name="MobileHeaderBar" IsVisible="False" Padding="5, 10, 5, 0">
+            <Grid Grid.Row="0" x:Name="MobileHeaderBar" IsVisible="False" Padding="5, 10">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="50"/>
+                    <RowDefinition Height="40"/>
                     <RowDefinition Height="40"/>
                     <RowDefinition Height="40" />
                 </Grid.RowDefinitions>
@@ -87,24 +132,36 @@
                 </Grid>
 
                 <Grid Grid.Row="1">
-                    <Entry Placeholder="Search" ClearButtonVisibility="WhileEditing" Completed="search_event" />
+                    <Entry Placeholder="Search" TextColor="{StaticResource PrimaryBlack}" ClearButtonVisibility="WhileEditing" Completed="search_event" />
                 </Grid>
 
-                <Grid Grid.Row="2" Padding="5, 10, 5, 0">
+                <Grid Grid.Row="2" Padding="5, 15, 5, 0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <Button Grid.Column="0" Text="Previous" x:Name="previousButtonMob" HorizontalOptions="Start" Clicked="PreviousButton_Clicked" FontAttributes="Bold" FontSize="16"/>
+                    <Button Grid.Column="0"
+                            Text="&lt;&lt; Previous"
+                            x:Name="previousButtonMob"
+                            HorizontalOptions="Start"
+                            Clicked="PreviousButton_Clicked"
+                            FontAttributes="Bold"
+                            FontSize="16"/>
                     <Picker Grid.Column="1" x:Name="mobilePicker" Title="Sort" SelectedIndexChanged="SortPicker_SelectedIndexChanged" />
-                    <Button Grid.Column="2" Text="Next" x:Name="nextButtonMob" HorizontalOptions="End" Clicked="NextButton_Clicked" FontAttributes="Bold" FontSize="16"/>
+                    <Button Grid.Column="2"
+                            Text="Next >>"
+                            x:Name="nextButtonMob"
+                            HorizontalOptions="End"
+                            Clicked="NextButton_Clicked"
+                            FontAttributes="Bold"
+                            FontSize="16"/>
                 </Grid>
             </Grid>
 
             <StackLayout Grid.Row="1" x:Name="DesktopCasesList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
+                <Frame BackgroundColor="#147efb" Padding="0" Margin="0, 0, 0, 10" HasShadow="False">
                     <Grid HeightRequest="40">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
@@ -175,7 +232,7 @@
             </StackLayout>
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobileCasesList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
+                <Frame BackgroundColor="#147efb" Padding="0" Margin="0, 0, 0, 10" HasShadow="False">
                     <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">

--- a/DreamInventory/Views/Case/CasesPage.xaml
+++ b/DreamInventory/Views/Case/CasesPage.xaml
@@ -180,7 +180,7 @@
 
                         <Label Margin="10,0,10,0" Text="Case No" VerticalOptions="Center" Grid.Column="0" Style="{StaticResource DesktopListHeaderStyles}" />
                         <Label Margin="10,0,10,0" Text="Case Type" VerticalOptions="Center" Grid.Column="1" Style="{StaticResource DesktopListHeaderStyles}" />
-                        <Label Margin="10,0,10,0" Text="Filling Date" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource DesktopListHeaderStyles}" />
+                        <Label Margin="10,0,10,0" Text="Filing Date" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource DesktopListHeaderStyles}" />
                         <Label Margin="10,0,10,0" Text="Judge" VerticalOptions="Center" Grid.Column="3" Style="{StaticResource DesktopListHeaderStyles}" />
 
                         <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="0" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
@@ -250,7 +250,7 @@
 
                         <Label Margin="10,0,10,0" Text="Case No" VerticalOptions="Center" Grid.Column="0" Style="{StaticResource MobileListHeaderStyles}" />
                         <Label Margin="10,0,10,0" Text="Case Type" VerticalOptions="Center" Grid.Column="1" Style="{StaticResource MobileListHeaderStyles}" />
-                        <Label Margin="10,0,10,0" Text="Filling Date" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource MobileListHeaderStyles}" />
+                        <Label Margin="10,0,10,0" Text="Filing Date" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource MobileListHeaderStyles}" />
                         <Label Margin="10,0,10,0" Text="Judge" VerticalOptions="Center" Grid.Column="3" Style="{StaticResource MobileListHeaderStyles}" />
 
                         <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="0" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />

--- a/DreamInventory/Views/Case/CasesPage.xaml
+++ b/DreamInventory/Views/Case/CasesPage.xaml
@@ -176,7 +176,7 @@
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobileCasesList">
                 <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
-                    <Grid HeightRequest="50">
+                    <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
                                 <On Platform="iOS" Value="5" />

--- a/DreamInventory/Views/Case/CasesPage.xaml.cs
+++ b/DreamInventory/Views/Case/CasesPage.xaml.cs
@@ -26,8 +26,8 @@ namespace DreamInventory.Views.Case
             sortElements.Add("Case No desc");
             sortElements.Add("Case Type asc");
             sortElements.Add("Case Type desc");
-            sortElements.Add("Filling Date asc");
-            sortElements.Add("Filling Date desc");
+            sortElements.Add("Filing Date asc");
+            sortElements.Add("Filing Date desc");
             sortElements.Add("Judge asc");
             sortElements.Add("Judge desc");
 

--- a/DreamInventory/Views/Case/EditCasePage.xaml
+++ b/DreamInventory/Views/Case/EditCasePage.xaml
@@ -5,110 +5,304 @@
     xmlns:vm="clr-namespace:DreamInventory.ViewModels"
     x:Class="DreamInventory.Views.Case.EditCasePage">
 
-    <Grid BindingContext="{Binding}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="60" />
-            <RowDefinition Height="60" />
-            <RowDefinition Height="60" />
-            <RowDefinition Height="60" />
-            <RowDefinition Height="60" />
-            <RowDefinition Height="60" />
-        </Grid.RowDefinitions>
+    <StackLayout>
 
-        <Grid Grid.Row="0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+        <Grid BindingContext="{Binding}" x:Name="DesktopEditCaseForm" IsVisible="False" Margin="20, 40, 20, 0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="60" />
+                <RowDefinition Height="60" />
+                <RowDefinition Height="60" />
+                <RowDefinition Height="60" />
+                <RowDefinition Height="60" />
+                <RowDefinition Height="60" />
+                <RowDefinition Height="230" />
+                <RowDefinition Height="60" />
+            </Grid.RowDefinitions>
 
-            <StackLayout Grid.Column="0" Padding="10" Orientation="Horizontal">
-                <Button Command="{Binding EditCaseCommand, Source={vm:CaseViewModel}}" CommandParameter="{Binding}" Text="Update" WidthRequest="60" BackgroundColor="#4db2ff" />
+            <StackLayout Grid.Row="0">
+                <Label Text="{Binding CaseNo, StringFormat='Edit Case Number:  {0}'}"
+                       FontAttributes="Bold"
+                       FontSize="20" />
             </StackLayout>
+
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding Type}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Amount"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding Amount}"
+                           FontSize="14"
+                           HeightRequest="30"
+                           Keyboard="Numeric"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Court Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CourtType}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Case Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CaseType}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Filing Date"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <DatePicker Date="{Binding FillingDate}"
+                                HeightRequest="25"
+                                FontSize="14"
+                                Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Judge"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding Judge}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Case No"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CaseNo}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Case URL"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CaseUrl}"
+                           HeightRequest="30"
+                           Keyboard="Url"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Docket Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding DocketType}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Description"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Editor Text="{Binding Description}"
+                            HeightRequest="200"
+                            FontSize="14"
+                            BackgroundColor="White"
+                            Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="7">
+                <StackLayout Padding="0, 10, 10, 10" Orientation="Horizontal">
+                    <Button Text="Update"
+                            Command="{Binding EditCaseCommand, Source={vm:CaseViewModel}}"
+                            CommandParameter="{Binding}"
+                            WidthRequest="70"
+                            BackgroundColor="#147efb"
+                            TextColor="#FFFFFF"
+                            FontAttributes="Bold"
+                            FontSize="14"
+                            CornerRadius="5"
+                            BorderWidth="2"
+                            BorderColor="#147efb" />
+                </StackLayout>
+            </Grid>
         </Grid>
 
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+        <StackLayout BindingContext="{Binding}" x:Name="MobileEditCaseForm" IsVisible="False" Padding="20">
+            <ScrollView>
+                <StackLayout>
+                    <StackLayout>
+                        <Label Text="{Binding CaseNo, StringFormat='Edit Case Number: {0}'}"
+                               FontAttributes="Bold"
+                               FontSize="Large"
+                               TextColor="{StaticResource PrimaryBlack}" />
+                    </StackLayout>
 
-            <StackLayout Grid.Column="0" Padding="10">
-                <Label Text="{Binding}" />
-                <Entry Text="{Binding Type}" HeightRequest="30" />
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding Type}"
+                               HeightRequest="40"
+                               Placeholder="Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding Amount}"
+                               HeightRequest="40"
+                               Keyboard="Numeric"
+                               Placeholder="Amount"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CourtType}"
+                               HeightRequest="40"
+                               Placeholder="Court Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CaseType}"
+                               HeightRequest="40"
+                               Placeholder="Case Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <DatePicker Date="{Binding FillingDate}"
+                                    HeightRequest="40"
+                                    TextColor="{StaticResource PrimaryBlack}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding Judge}"
+                               HeightRequest="40"
+                               Placeholder="Judge Name"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CaseNo}"
+                               HeightRequest="40"
+                               Placeholder="Case Number"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CaseUrl}"
+                               HeightRequest="40"
+                               Keyboard="Url"
+                               Placeholder="Case URL"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding DocketType}"
+                               HeightRequest="40"
+                               Placeholder="Docket Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
+
+                    <StackLayout Padding="0, 20, 0, 0" HeightRequest="160">
+                        <Frame BorderColor="LightGray" CornerRadius="5" HasShadow="False" Padding="2">
+                            <Editor Text="{Binding Description}"
+                                    HeightRequest="150"
+                                    BackgroundColor="White"
+                                    Placeholder="Description"
+                                    Style="{StaticResource FormFieldAndLableStyles}" />
+                        </Frame>
+                    </StackLayout>
+                </StackLayout>
+            </ScrollView>
+
+            <StackLayout Padding="0, 20, 0, 0">
+                <Button Text="Update"
+                        Command="{Binding EditCaseCommand, Source={vm:CaseViewModel}}"
+                        CommandParameter="{Binding}"
+                        WidthRequest="100"
+                        BackgroundColor="#147efb"
+                        TextColor="#FFFFFF"
+                        FontAttributes="Bold"
+                        FontSize="16" />
             </StackLayout>
+        </StackLayout>
 
-            <StackLayout Grid.Column="1" Padding="10">
-                <Label Text="Amount" />
-                <Entry Text="{Binding Amount}" HeightRequest="30" Keyboard="Numeric" />
-            </StackLayout>
-        </Grid>
+    </StackLayout>
 
-        <Grid Grid.Row="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <StackLayout Grid.Column="0" Padding="10">
-                <Label Text="Court Type" />
-                <Entry Text="{Binding CourtType}" HeightRequest="30" />
-            </StackLayout>
-
-            <StackLayout Grid.Column="1" Padding="10">
-                <Label Text="Case Type" />
-                <Entry Text="{Binding CaseType}" HeightRequest="30" />
-            </StackLayout>
-        </Grid>
-
-        <Grid Grid.Row="3">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <StackLayout Grid.Column="0" Padding="10">
-                <Label Text="Filing Date" />
-                <DatePicker Date="{Binding FillingDate}" HeightRequest="30" />
-            </StackLayout>
-
-            <StackLayout Grid.Column="1" Padding="10">
-                <Label Text="Judge" />
-                <Entry Text="{Binding Judge}" HeightRequest="30" />
-            </StackLayout>
-        </Grid>
-
-        <Grid Grid.Row="4">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <StackLayout Grid.Column="0" Padding="10">
-                <Label Text="Case No" />
-                <Entry Text="{Binding CaseNo}" HeightRequest="30" />
-            </StackLayout>
-
-            <StackLayout Grid.Column="1" Padding="10">
-                <Label Text="Case URL" />
-                <Entry Text="{Binding CaseUrl}" HeightRequest="30" />
-            </StackLayout>
-        </Grid>
-
-        <Grid Grid.Row="5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <StackLayout Grid.Column="0" Padding="10">
-                <Label Text="Docket Type" />
-                <Entry Text="{Binding DocketType}" HeightRequest="30" />
-            </StackLayout>
-
-            <StackLayout Grid.Column="1" Padding="10">
-                <Label Text="Description" />
-                <Entry Text="{Binding Description}" HeightRequest="30" />
-            </StackLayout>
-        </Grid>
-    </Grid>
 </ContentPage>

--- a/DreamInventory/Views/Case/EditCasePage.xaml
+++ b/DreamInventory/Views/Case/EditCasePage.xaml
@@ -67,7 +67,7 @@
             </Grid.ColumnDefinitions>
 
             <StackLayout Grid.Column="0" Padding="10">
-                <Label Text="Filling Date" />
+                <Label Text="Filing Date" />
                 <DatePicker Date="{Binding FillingDate}" HeightRequest="30" />
             </StackLayout>
 

--- a/DreamInventory/Views/Case/EditCasePage.xaml.cs
+++ b/DreamInventory/Views/Case/EditCasePage.xaml.cs
@@ -11,6 +11,17 @@ namespace DreamInventory.Views.Case
         {
             InitializeComponent();
 
+            if (Device.RuntimePlatform == Device.macOS)
+            {
+                MobileEditCaseForm.IsVisible = false;
+                DesktopEditCaseForm.IsVisible = true;
+            }
+            else
+            {
+                MobileEditCaseForm.IsVisible = true;
+                DesktopEditCaseForm.IsVisible = false;
+            }
+
             BindingContext = caseObject;
         }
     }

--- a/DreamInventory/Views/Case/NewCasePage.xaml
+++ b/DreamInventory/Views/Case/NewCasePage.xaml
@@ -22,7 +22,7 @@
                 <RowDefinition Height="60" />
             </Grid.RowDefinitions>
 
-            <StackLayout>
+            <StackLayout Grid.Row="0">
                 <Label Text="Add Case Details"
                        FontAttributes="Bold"
                        FontSize="20" />
@@ -295,8 +295,8 @@
             </ScrollView>
 
             <StackLayout Padding="0, 20, 0, 0">
-                <Button Command="{Binding AddCaseCommand}"
-                        Text="Save"
+                <Button Text="Save"
+                        Command="{Binding AddCaseCommand}"
                         WidthRequest="100"
                         BackgroundColor="#147efb"
                         TextColor="#FFFFFF"

--- a/DreamInventory/Views/Case/NewCasePage.xaml
+++ b/DreamInventory/Views/Case/NewCasePage.xaml
@@ -10,7 +10,7 @@
 
     <StackLayout>
 
-        <Grid x:Name="DesktopNewCaseForm" IsVisible="False">
+        <Grid x:Name="DesktopNewCaseForm" IsVisible="False" Margin="20, 40, 20, 0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="60" />
                 <RowDefinition Height="60" />
@@ -18,18 +18,15 @@
                 <RowDefinition Height="60" />
                 <RowDefinition Height="60" />
                 <RowDefinition Height="60" />
+                <RowDefinition Height="230" />
+                <RowDefinition Height="60" />
             </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <StackLayout Grid.Column="0" Padding="10" Orientation="Horizontal">
-                    <Button Command="{Binding AddCaseCommand}" Text="Save" WidthRequest="60" BackgroundColor="#4db2ff" />
-                </StackLayout>
-            </Grid>
+            <StackLayout>
+                <Label Text="Add Case Details"
+                       FontAttributes="Bold"
+                       FontSize="20" />
+            </StackLayout>
 
             <Grid Grid.Row="1">
                 <Grid.ColumnDefinitions>
@@ -37,14 +34,27 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <StackLayout Grid.Column="0" Padding="10">
-                    <Label Text="Type" />
-                    <Entry Text="{Binding Type}" HeightRequest="30" />
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding Type}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
 
-                <StackLayout Grid.Column="1" Padding="10">
-                    <Label Text="Amount" />
-                    <Entry Text="{Binding Amount}" HeightRequest="30" Keyboard="Numeric" />
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Amount"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding Amount}"
+                           FontSize="14"
+                           HeightRequest="30"
+                           Keyboard="Numeric"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
             </Grid>
 
@@ -54,14 +64,26 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <StackLayout Grid.Column="0" Padding="10">
-                    <Label Text="Court Type" />
-                    <Entry Text="{Binding CourtType}" HeightRequest="30" />
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Court Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CourtType}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
 
-                <StackLayout Grid.Column="1" Padding="10">
-                    <Label Text="Case Type" />
-                    <Entry Text="{Binding CaseType}" HeightRequest="30" />
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Case Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CaseType}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
             </Grid>
 
@@ -71,14 +93,26 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <StackLayout Grid.Column="0" Padding="10">
-                    <Label Text="Filling Date" />
-                    <DatePicker Date="{Binding FillingDate}" HeightRequest="30" />
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Filing Date"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <DatePicker Date="{Binding FillingDate}"
+                                HeightRequest="25"
+                                FontSize="14"
+                                Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
 
-                <StackLayout Grid.Column="1" Padding="10">
-                    <Label Text="Judge" />
-                    <Entry Text="{Binding Judge}" HeightRequest="30" />
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Judge"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding Judge}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
             </Grid>
 
@@ -88,14 +122,27 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <StackLayout Grid.Column="0" Padding="10">
-                    <Label Text="Case No" />
-                    <Entry Text="{Binding CaseNo}" HeightRequest="30" />
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Case No"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CaseNo}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
 
-                <StackLayout Grid.Column="1" Padding="10">
-                    <Label Text="Case URL" />
-                    <Entry Text="{Binding CaseUrl}" HeightRequest="30" Keyboard="Url" />
+                <StackLayout Grid.Column="1" Padding="20, 0, 0, 0">
+                    <Label Text="Case URL"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding CaseUrl}"
+                           HeightRequest="30"
+                           Keyboard="Url"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
             </Grid>
 
@@ -105,105 +152,147 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <StackLayout Grid.Column="0" Padding="10">
-                    <Label Text="Docket Type" />
-                    <Entry Text="{Binding DocketType}" HeightRequest="30" />
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Docket Type"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Entry Text="{Binding DocketType}"
+                           HeightRequest="30"
+                           FontSize="14"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
                 </StackLayout>
+            </Grid>
 
-                <StackLayout Grid.Column="1" Padding="10">
-                    <Label Text="Description" />
-                    <Entry Text="{Binding Description}" HeightRequest="30" />
+            <Grid Grid.Row="6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Grid.Column="0" Padding="0, 0, 20, 0">
+                    <Label Text="Description"
+                           FontSize="14"
+                           FontAttributes="Bold"
+                           Style="{StaticResource FormFieldAndLableStyles}" />
+                    <Editor Text="{Binding Description}"
+                            HeightRequest="200"
+                            FontSize="14"
+                            BackgroundColor="White"
+                            Style="{StaticResource FormFieldAndLableStyles}" />
+                </StackLayout>
+            </Grid>
+
+            <Grid Grid.Row="7">
+                <StackLayout Padding="0, 10, 10, 10" Orientation="Horizontal">
+                    <Button Text="Save"
+                            Command="{Binding AddCaseCommand}"
+                            WidthRequest="70"
+                            BackgroundColor="#147efb"
+                            TextColor="#FFFFFF"
+                            FontAttributes="Bold"
+                            FontSize="14"
+                            CornerRadius="5"
+                            BorderWidth="2"
+                            BorderColor="#147efb" />
                 </StackLayout>
             </Grid>
 
         </Grid>
 
         <StackLayout x:Name="MobileNewCaseForm" IsVisible="False" Padding="20">
-            <StackLayout>
-                <Label Text="Add Case Details"
-                       FontAttributes="Bold"
-                       FontSize="Large" />
-            </StackLayout>
+            <ScrollView>
+                <StackLayout>
+                    <StackLayout>
+                        <Label Text="Add Case Details"
+                               FontAttributes="Bold"
+                               FontSize="Large"
+                               TextColor="{StaticResource PrimaryBlack}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding Type}"
-                       HeightRequest="40"
-                       Placeholder="Type"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding Type}"
+                               HeightRequest="40"
+                               Placeholder="Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding Amount}"
-                       HeightRequest="40"
-                       Keyboard="Numeric"
-                       Placeholder="Amount"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding Amount}"
+                               HeightRequest="40"
+                               Keyboard="Numeric"
+                               Placeholder="Amount"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding CourtType}"
-                       HeightRequest="40"
-                       Placeholder="Court Type"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CourtType}"
+                               HeightRequest="40"
+                               Placeholder="Court Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding CaseType}"
-                       HeightRequest="40"
-                       Placeholder="Case Type"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CaseType}"
+                               HeightRequest="40"
+                               Placeholder="Case Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <DatePicker Date="{Binding FillingDate}"
-                            HeightRequest="40"
-                            TextColor="#333333" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <DatePicker Date="{Binding FillingDate}"
+                                    HeightRequest="40"
+                                    TextColor="{StaticResource PrimaryBlack}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding Judge}"
-                       HeightRequest="40"
-                       Placeholder="Judge Name"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding Judge}"
+                               HeightRequest="40"
+                               Placeholder="Judge Name"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding CaseNo}"
-                       HeightRequest="40"
-                       Placeholder="Case Number"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CaseNo}"
+                               HeightRequest="40"
+                               Placeholder="Case Number"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding CaseUrl}"
-                       HeightRequest="40"
-                       Keyboard="Url"
-                       Placeholder="Case URL"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding CaseUrl}"
+                               HeightRequest="40"
+                               Keyboard="Url"
+                               Placeholder="Case URL"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding DocketType}"
-                       HeightRequest="40"
-                       Placeholder="Docket Type"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0">
+                        <Entry Text="{Binding DocketType}"
+                               HeightRequest="40"
+                               Placeholder="Docket Type"
+                               ClearButtonVisibility="WhileEditing"
+                               Style="{StaticResource FormFieldAndLableStyles}" />
+                    </StackLayout>
 
-            <StackLayout Padding="0, 20, 0, 0">
-                <Entry Text="{Binding Description}"
-                       HeightRequest="40"
-                       Placeholder="Description"
-                       PlaceholderColor="#333333"
-                       ClearButtonVisibility="WhileEditing" />
-            </StackLayout>
+                    <StackLayout Padding="0, 20, 0, 0" HeightRequest="160">
+                        <Frame BorderColor="LightGray" CornerRadius="5" HasShadow="False" Padding="2">
+                            <Editor Text="{Binding Description}"
+                                    HeightRequest="150"
+                                    BackgroundColor="White"
+                                    Placeholder="Description"
+                                    Style="{StaticResource FormFieldAndLableStyles}" />
+                        </Frame>
+                    </StackLayout>
+                </StackLayout>
+            </ScrollView>
 
             <StackLayout Padding="0, 20, 0, 0">
                 <Button Command="{Binding AddCaseCommand}"
@@ -219,3 +308,4 @@
     </StackLayout>
 
 </ContentPage>
+ 

--- a/DreamInventory/Views/Case/NewCasePage.xaml.cs
+++ b/DreamInventory/Views/Case/NewCasePage.xaml.cs
@@ -22,5 +22,9 @@ namespace DreamInventory.Views.Case
                 DesktopNewCaseForm.IsVisible = false;
             }
         }
+
+        void Editor_TextChanged(System.Object sender, Xamarin.Forms.TextChangedEventArgs e)
+        {
+        }
     }
 }

--- a/DreamInventory/Views/Case/ShowCasePage.xaml
+++ b/DreamInventory/Views/Case/ShowCasePage.xaml
@@ -27,8 +27,7 @@
                     </Grid.RowDefinitions>
 
                     <StackLayout Grid.Row="0">
-                        <Label
-                            Text="{Binding CaseNo, StringFormat='Case Number:  {0}'}"
+                        <Label Text="{Binding CaseNo, StringFormat='Case Number:  {0}'}"
                             FontAttributes="Bold"
                             FontSize="Large" />
                     </StackLayout>

--- a/DreamInventory/Views/Case/ShowCasePage.xaml
+++ b/DreamInventory/Views/Case/ShowCasePage.xaml
@@ -336,7 +336,7 @@
                         </Grid.ColumnDefinitions>
 
                         <Grid Grid.Column="0">
-                            <Label Text="Filling Date"
+                            <Label Text="Filing Date"
                                    HorizontalOptions="Start"
                                    Style="{StaticResource DesktopShowCasesDetailHeadStyles}" />
                             <Label Text=":"

--- a/DreamInventory/Views/Case/ShowCasePage.xaml
+++ b/DreamInventory/Views/Case/ShowCasePage.xaml
@@ -208,7 +208,7 @@
         </Grid>
 
         <ScrollView x:Name="DesktopShowCases">
-            <Grid BindingContext="{Binding}" Padding="30" Margin="0, 50, 0, 0">
+            <Grid BindingContext="{Binding}" Padding="30" Margin="0, 20, 0, 0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="40" />
                     <RowDefinition Height="Auto" />

--- a/DreamInventory/Views/Defendant/DefendantsPage.xaml
+++ b/DreamInventory/Views/Defendant/DefendantsPage.xaml
@@ -88,7 +88,7 @@
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobileDefendantsList">
                 <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
-                    <Grid HeightRequest="50">
+                    <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
                                 <On Platform="iOS" Value="5" />

--- a/DreamInventory/Views/Plaintiff/PlaintiffsPage.xaml
+++ b/DreamInventory/Views/Plaintiff/PlaintiffsPage.xaml
@@ -88,7 +88,7 @@
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobilePlaintiffsList">
                 <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
-                    <Grid HeightRequest="50">
+                    <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
                                 <On Platform="iOS" Value="5" />


### PR DESCRIPTION
**UI changes for:**
 - Edit cases page for MacOS and iOS
 - New cases page for MacOS and iOS
 - Listing page header section for MacOS

 - Minor UI tweaks on listing page iOS header section
 - Editor box for Case Description field


**iOS**

![image](https://user-images.githubusercontent.com/19545625/77552835-0a1fbf00-6eda-11ea-8783-3ec0992ab9d4.png)

![image](https://user-images.githubusercontent.com/19545625/77552912-24f23380-6eda-11ea-8a49-686003114610.png)

![image](https://user-images.githubusercontent.com/19545625/77553071-5408a500-6eda-11ea-9513-cd0c93ebccac.png)



**MacOS**

![image](https://user-images.githubusercontent.com/19545625/77553487-dee99f80-6eda-11ea-80f3-05ea92d0b0b5.png)

![image](https://user-images.githubusercontent.com/19545625/77553420-cb3e3900-6eda-11ea-9374-467af6fc8857.png)

![image](https://user-images.githubusercontent.com/19545625/77553349-b497e200-6eda-11ea-80cb-0195ae983e2f.png)

