### PR TITLE
UI - Alternate rows color, cancel button and menu styles fixes

### DIFF
--- a/DreamInventory/App.xaml
+++ b/DreamInventory/App.xaml
@@ -4,7 +4,7 @@
         <ResourceDictionary>
 
             <!--Colors-->
-            <Color x:Key="NavigationPrimary">#147efb</Color>
+            <Color x:Key="NavigationPrimary">#4a69ff</Color>
             <Color x:Key="PrimaryBlack">#333333</Color>
 
             <!--Global Label Color-->

--- a/DreamInventory/MasterPage.xaml
+++ b/DreamInventory/MasterPage.xaml
@@ -7,7 +7,7 @@
     <MasterDetailPage.Master>
         <ContentPage BackgroundColor="#D6D6D6" Title="Menu">
             <ContentPage.Content>
-                <Grid HorizontalOptions="Start" WidthRequest="1000">
+                <Grid HorizontalOptions="Start" WidthRequest="1000" BackgroundColor="#333333">
                     <Grid.Margin>
                         <OnPlatform x:TypeArguments="Thickness">
                             <On Platform="iOS" Value="0, 50, 0, 5" />
@@ -20,7 +20,7 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <StackLayout Grid.Row="0" Grid.Column="0" BackgroundColor="#147efb" HeightRequest="120" Orientation="Horizontal" Padding="5">
+                    <StackLayout Grid.Row="0" Grid.Column="0" BackgroundColor="#333333" HeightRequest="120" Orientation="Horizontal" Padding="5">
                         <!--<Label Text="|||" FontAttributes="Bold"  />-->
 
                         <!--sample code for a icon-->
@@ -31,7 +31,7 @@
                                FontFamily="{StaticResource FontAwesomeRegular}" />-->
                         <Frame HeightRequest="25" WidthRequest="25" CornerRadius="30" VerticalOptions="Center" 
                            BackgroundColor="White" Margin="10" HasShadow="False">
-                            <Label Text="D" FontAttributes="Bold" FontSize="Large" TextColor="#147efb" 
+                            <Label Text="D" FontAttributes="Bold" FontSize="Large" TextColor="#333333"
                                VerticalOptions="Center" HorizontalOptions="Center" HeightRequest="-1"/>
                         </Frame>
                         <StackLayout VerticalOptions="Center" Spacing="2">
@@ -50,7 +50,7 @@
                                 <RowDefinition Height="40" />
                             </Grid.RowDefinitions>
                             <StackLayout Grid.Row="0">
-                                <Label Text="Cases" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5">
+                                <Label Text="Cases" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" TextColor="#575757">
                                     <Label.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Tapped="Cases_Tapped"
@@ -59,7 +59,7 @@
                                 </Label>
                             </StackLayout>
                             <StackLayout Grid.Row="1">
-                                <Label Text="Defendants" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5">
+                                <Label Text="Defendants" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" TextColor="#575757">
                                     <Label.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Tapped="Defendants_Tapped"
@@ -68,7 +68,7 @@
                                 </Label>
                             </StackLayout>
                             <StackLayout Grid.Row="2">
-                                <Label Text="Plaintiffs" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5">
+                                <Label Text="Plaintiffs" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" TextColor="#575757">
                                     <Label.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Tapped="Plaintiffs_Tapped"
@@ -85,7 +85,7 @@
                                 <RowDefinition Height="40" />
                             </Grid.RowDefinitions>
                             <StackLayout Grid.Row="0">
-                                <Label Text="Cases" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" FontAttributes="Bold">
+                                <Label Text="Cases" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" FontAttributes="Bold" TextColor="#575757">
                                     <Label.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Tapped="Cases_Tapped"
@@ -94,7 +94,7 @@
                                 </Label>
                             </StackLayout>
                             <StackLayout Grid.Row="1">
-                                <Label Text="Defendants" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" FontAttributes="Bold">
+                                <Label Text="Defendants" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" FontAttributes="Bold" TextColor="#575757">
                                     <Label.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Tapped="Defendants_Tapped"
@@ -103,7 +103,7 @@
                                 </Label>
                             </StackLayout>
                             <StackLayout Grid.Row="2">
-                                <Label Text="Plaintiffs" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" FontAttributes="Bold">
+                                <Label Text="Plaintiffs" BackgroundColor="Transparent" FontSize="Medium" LineHeight="1.5" FontAttributes="Bold" TextColor="#575757">
                                     <Label.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Tapped="Plaintiffs_Tapped"

--- a/DreamInventory/Models/Cases.cs
+++ b/DreamInventory/Models/Cases.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using Xamarin.Forms;
 
 namespace DreamInventory
 {
@@ -20,6 +21,7 @@ namespace DreamInventory
         public string CaseUrl { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
+        public Color ViewCellBackgroundColor { get; internal set; }
     }
 
     public class CaseData

--- a/DreamInventory/Views/Case/CasesPage.xaml
+++ b/DreamInventory/Views/Case/CasesPage.xaml
@@ -51,7 +51,7 @@
                     </Grid.ColumnDefinitions>
 
                     <StackLayout Grid.Column="0" HorizontalOptions="Start" VerticalOptions="Center">
-                        <Label Text="+ Add Case" TextColor="#147efb" FontSize="14" FontAttributes="Bold" >
+                        <Label Text="+ Add Case" TextColor="#4a69ff" FontSize="14" FontAttributes="Bold" >
                             <Label.GestureRecognizers>
                                 <TapGestureRecognizer Tapped="NewCase_Tapped" />
                             </Label.GestureRecognizers>
@@ -82,7 +82,7 @@
                                 WidthRequest="100"
                                 HorizontalOptions="Start"
                                 Clicked="PreviousButton_Clicked"
-                                TextColor="#147efb"
+                                TextColor="#4a69ff"
                                 FontSize="14"
                                 FontAttributes="Bold"
                                 CornerRadius="5"
@@ -94,7 +94,7 @@
                                 WidthRequest="70"
                                 HorizontalOptions="End"
                                 Clicked="NextButton_Clicked"
-                                TextColor="#147efb"
+                                TextColor="#4a69ff"
                                 FontSize="14"
                                 FontAttributes="Bold"
                                 CornerRadius="5"
@@ -123,7 +123,7 @@
                     </StackLayout>
 
                     <StackLayout Grid.Column="1">
-                        <Label Text="+ Add Case" TextColor="#147efb" FontSize="16" FontAttributes="Bold" HorizontalOptions="End" Padding="0, 5, 0, 0">
+                        <Label Text="+ Add Case" TextColor="#4a69ff" FontSize="16" FontAttributes="Bold" HorizontalOptions="End" Padding="0, 5, 0, 0">
                             <Label.GestureRecognizers>
                                 <TapGestureRecognizer Tapped="NewCase_Tapped" />
                             </Label.GestureRecognizers>
@@ -147,78 +147,88 @@
             </Grid>
 
             <StackLayout Grid.Row="1" x:Name="DesktopCasesList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0, 0, 0, 10" HasShadow="False">
-                    <Grid HeightRequest="40">
-                        <Grid.Margin>
-                            <OnPlatform x:TypeArguments="Thickness">
-                                <On Platform="iOS" Value="5" />
-                                <On Platform="Android, UWP" Value="5" />
-                                <On Platform="macOS" Value="10" />
-                            </OnPlatform>
-                        </Grid.Margin>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="40" />
+                    </Grid.RowDefinitions>
+                    <StackLayout Grid.Row="0">
+                        <Frame BackgroundColor="#4a69ff" Padding="0" Margin="0, 0, 0, 0" HasShadow="False">
+                            <Grid HeightRequest="60">
+                                <Grid.Margin>
+                                    <OnPlatform x:TypeArguments="Thickness">
+                                        <On Platform="iOS" Value="5" />
+                                        <On Platform="Android, UWP" Value="5" />
+                                        <On Platform="macOS" Value="10" />
+                                    </OnPlatform>
+                                </Grid.Margin>
 
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
 
-                        <Label Margin="10,0,10,0" Text="Case No" VerticalOptions="Center" Grid.Column="0" Style="{StaticResource DesktopListHeaderStyles}" />
-                        <Label Margin="10,0,10,0" Text="Case Type" VerticalOptions="Center" Grid.Column="1" Style="{StaticResource DesktopListHeaderStyles}" />
-                        <Label Margin="10,0,10,0" Text="Filing Date" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource DesktopListHeaderStyles}" />
-                        <Label Margin="10,0,10,0" Text="Judge" VerticalOptions="Center" Grid.Column="3" Style="{StaticResource DesktopListHeaderStyles}" />
+                                <Label Margin="10,0,10,0" Text="Case No" VerticalOptions="Center" Grid.Column="0" Style="{StaticResource DesktopListHeaderStyles}" />
+                                <Label Margin="10,0,10,0" Text="Case Type" VerticalOptions="Center" Grid.Column="1" Style="{StaticResource DesktopListHeaderStyles}" />
+                                <Label Margin="10,0,10,0" Text="Filing Date" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource DesktopListHeaderStyles}" />
+                                <Label Margin="10,0,10,0" Text="Judge" VerticalOptions="Center" Grid.Column="3" Style="{StaticResource DesktopListHeaderStyles}" />
 
-                        <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="0" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
-                        <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="1" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
-                        <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="2" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
-                    </Grid>
-                </Frame>
+                                <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="0" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
+                                <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="1" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
+                                <BoxView BackgroundColor="White" WidthRequest="1" Grid.Column="2" HorizontalOptions="EndAndExpand" VerticalOptions="FillAndExpand" />
+                            </Grid>
+                        </Frame>
 
-                <ListView ItemsSource="{Binding}" ItemTapped="ListView_ItemTapped" HasUnevenRows="True" BackgroundColor="White">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <ViewCell>
-                                <Frame BorderColor="#cccccc" HasShadow="False" Margin="1">
-                                    <Grid HeightRequest="20" Margin="-15" Padding="3">
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
-                                        </Grid.RowDefinitions>
-                                        <Grid Grid.Row="0">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="*" />
-                                            </Grid.ColumnDefinitions>
+                        <ListView ItemsSource="{Binding}" ItemTapped="ListView_ItemTapped" HasUnevenRows="True" BackgroundColor="White">
+                            <ListView.ItemTemplate>
+                                <DataTemplate>
+                                    <ViewCell>
+                                        <Grid HeightRequest="60" BackgroundColor="{Binding ViewCellBackgroundColor}">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="*" />
+                                            </Grid.RowDefinitions>
+                                            <Grid Grid.Row="0" Padding="10, 0, 0, 0">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
 
-                                            <Label Text="{Binding CaseNo}" VerticalOptions="Center" Grid.Column="0" FontAttributes="Bold" Style="{StaticResource DesktopListContentStyles}" />
-                                            <Label Text="{Binding CaseType}" VerticalOptions="Center" Grid.Column="1" Style="{StaticResource DesktopListContentStyles}" />
-                                            <Label Text="{Binding FillingDate}" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource DesktopListContentStyles}" />
-                                            <Label Text="{Binding Judge}" VerticalOptions="Center" Grid.Column="3" Style="{StaticResource DesktopListContentStyles}" />
+                                                <Label Text="{Binding CaseNo}" VerticalOptions="Center" Grid.Column="0" FontAttributes="Bold" Style="{StaticResource DesktopListContentStyles}" />
+                                                <Label Text="{Binding CaseType}" VerticalOptions="Center" Grid.Column="1" Style="{StaticResource DesktopListContentStyles}" />
+                                                <Label Text="{Binding FillingDate}" VerticalOptions="Center" Grid.Column="2" Style="{StaticResource DesktopListContentStyles}" />
+                                                <Label Text="{Binding Judge}" VerticalOptions="Center" Grid.Column="3" Style="{StaticResource DesktopListContentStyles}" />
+                                            </Grid>
                                         </Grid>
-                                    </Grid>
-                                </Frame>
-                            </ViewCell>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
-                <StackLayout Orientation="Horizontal">
-                    <Label Text="Page" />
-                    <Entry x:Name="CurrentPageEntry"
-                           Keyboard="Numeric"
-                           WidthRequest="30" HeightRequest="20"
-                           HorizontalTextAlignment="Center"
-                           VerticalTextAlignment="Center"
-                           MaxLength="5"
-                           TextChanged="CurrentPageEntry_TextChanged"
-                           Completed="CurrentPageEntry_Completed"/>
-                    <Label x:Name="TotalPagesLabel" />
-                </StackLayout>
+                                    </ViewCell>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                    </StackLayout>
+                    <StackLayout Grid.Row="1" VerticalOptions="End">
+                        <StackLayout Orientation="Horizontal" HorizontalOptions="End">
+                        <Label Text="Page" FontSize="14" />
+                        <Entry x:Name="CurrentPageEntry"
+                               Keyboard="Numeric"
+                               WidthRequest="30"
+                               HeightRequest="20"
+                               HorizontalTextAlignment="Center"
+                               VerticalTextAlignment="Center"
+                               MaxLength="5"
+                               FontSize="14"
+                               TextChanged="CurrentPageEntry_TextChanged"
+                               Completed="CurrentPageEntry_Completed"/>
+                        <Label x:Name="TotalPagesLabel" FontSize="14" />
+                    </StackLayout>
+                    </StackLayout>
+                </Grid>
             </StackLayout>
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobileCasesList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0, 0, 0, 10" HasShadow="False">
+                <Frame BackgroundColor="#4a69ff" Padding="0" Margin="0, 0, 0, 10" HasShadow="False">
                     <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
@@ -249,7 +259,7 @@
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <ViewCell>
-                                <Frame HasShadow="False" BorderColor="#cccccc" Margin="0, 0, 0, 10">
+                                <Frame HasShadow="False" BackgroundColor="{Binding ViewCellBackgroundColor}">
                                     <Grid Padding="-10">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />

--- a/DreamInventory/Views/Case/CasesPage.xaml.cs
+++ b/DreamInventory/Views/Case/CasesPage.xaml.cs
@@ -90,8 +90,28 @@ namespace DreamInventory.Views.Case
             CasesCountDesktop.Text = CaseCount;
             CasesCountMob.Text = CaseCount;
 
+            setBgColor();
+
             BindingContext = CurrentViewCases;
             base.OnAppearing();
+        }
+
+        private void setBgColor()
+        {
+            int count = 0;
+            foreach(Cases a in CurrentViewCases)
+            {
+                if(IsOdd(count))
+                {
+                    a.ViewCellBackgroundColor = Color.FromHex("#ffffff");
+                }
+                else
+                {
+                    a.ViewCellBackgroundColor = Color.FromRgba(0, 0, 0, .05);
+                }
+
+                count++;
+            }
         }
 
         void NextButton_Clicked(object sender, EventArgs e)
@@ -204,8 +224,16 @@ namespace DreamInventory.Views.Case
                 CurrentViewCases.AddRange(newList);
 
                 CasesCollection = new ObservableCollection<Cases>(CurrentViewCases);
+
+                setBgColor();
+
                 BindingContext = CasesCollection;
             }
+        }
+
+        private bool IsOdd(int viewCellIndex)
+        {
+            return (viewCellIndex % 2 != 0) ? true : false;
         }
     }
 }

--- a/DreamInventory/Views/Case/EditCasePage.xaml
+++ b/DreamInventory/Views/Case/EditCasePage.xaml
@@ -186,13 +186,23 @@
                             Command="{Binding EditCaseCommand, Source={vm:CaseViewModel}}"
                             CommandParameter="{Binding}"
                             WidthRequest="70"
-                            BackgroundColor="#147efb"
+                            BackgroundColor="#4a69ff"
                             TextColor="#FFFFFF"
                             FontAttributes="Bold"
                             FontSize="14"
                             CornerRadius="5"
                             BorderWidth="2"
-                            BorderColor="#147efb" />
+                            BorderColor="#4a69ff" />
+                    <Button Text="Cancel"
+                            Clicked="Cancel_Button_Clicked"
+                            WidthRequest="70"
+                            BackgroundColor="#555555"
+                            TextColor="#FFFFFF"
+                            FontAttributes="Bold"
+                            FontSize="14"
+                            CornerRadius="5"
+                            BorderWidth="2"
+                            BorderColor="#555555" />
                 </StackLayout>
             </Grid>
         </Grid>
@@ -296,7 +306,14 @@
                         Command="{Binding EditCaseCommand, Source={vm:CaseViewModel}}"
                         CommandParameter="{Binding}"
                         WidthRequest="100"
-                        BackgroundColor="#147efb"
+                        BackgroundColor="#4a69ff"
+                        TextColor="#FFFFFF"
+                        FontAttributes="Bold"
+                        FontSize="16" />
+                <Button Text="Cancel"
+                        Clicked="Cancel_Button_Clicked"
+                        WidthRequest="100"
+                        BackgroundColor="#555555"
                         TextColor="#FFFFFF"
                         FontAttributes="Bold"
                         FontSize="16" />

--- a/DreamInventory/Views/Case/EditCasePage.xaml.cs
+++ b/DreamInventory/Views/Case/EditCasePage.xaml.cs
@@ -24,5 +24,10 @@ namespace DreamInventory.Views.Case
 
             BindingContext = caseObject;
         }
+
+        void Cancel_Button_Clicked(System.Object sender, System.EventArgs e)
+        {
+            Navigation.PopAsync();
+        }
     }
 }

--- a/DreamInventory/Views/Case/NewCasePage.xaml
+++ b/DreamInventory/Views/Case/NewCasePage.xaml
@@ -188,13 +188,23 @@
                     <Button Text="Save"
                             Command="{Binding AddCaseCommand}"
                             WidthRequest="70"
-                            BackgroundColor="#147efb"
+                            BackgroundColor="#4a69ff"
                             TextColor="#FFFFFF"
                             FontAttributes="Bold"
                             FontSize="14"
                             CornerRadius="5"
                             BorderWidth="2"
-                            BorderColor="#147efb" />
+                            BorderColor="#4a69ff" />
+                    <Button Text="Cancel"
+                            Clicked="Cancel_Button_Clicked"
+                            WidthRequest="70"
+                            BackgroundColor="#555555"
+                            TextColor="#FFFFFF"
+                            FontAttributes="Bold"
+                            FontSize="14"
+                            CornerRadius="5"
+                            BorderWidth="2"
+                            BorderColor="#555555" />
                 </StackLayout>
             </Grid>
 
@@ -298,7 +308,14 @@
                 <Button Text="Save"
                         Command="{Binding AddCaseCommand}"
                         WidthRequest="100"
-                        BackgroundColor="#147efb"
+                        BackgroundColor="#4a69ff"
+                        TextColor="#FFFFFF"
+                        FontAttributes="Bold"
+                        FontSize="16" />
+                <Button Text="Cancel"
+                        Clicked="Cancel_Button_Clicked"
+                        WidthRequest="100"
+                        BackgroundColor="#555555"
                         TextColor="#FFFFFF"
                         FontAttributes="Bold"
                         FontSize="16" />

--- a/DreamInventory/Views/Case/NewCasePage.xaml.cs
+++ b/DreamInventory/Views/Case/NewCasePage.xaml.cs
@@ -26,5 +26,10 @@ namespace DreamInventory.Views.Case
         void Editor_TextChanged(System.Object sender, Xamarin.Forms.TextChangedEventArgs e)
         {
         }
+
+        void Cancel_Button_Clicked(System.Object sender, System.EventArgs e)
+        {
+            Navigation.PopAsync();
+        }
     }
 }

--- a/DreamInventory/Views/Case/ShowCasePage.xaml
+++ b/DreamInventory/Views/Case/ShowCasePage.xaml
@@ -191,7 +191,7 @@
             <StackLayout Grid.Row="1" Margin="0, 10, 0, 0" Padding="0, 0, 0, 30">
                 <Button Text="Edit"
                         CommandParameter="{Binding}"
-                        BackgroundColor="#147efb"
+                        BackgroundColor="#4a69ff"
                         Clicked="EditButton_Clicked"
                         TextColor="#FFFFFF"
                         FontAttributes="Bold"
@@ -442,14 +442,14 @@
                                 CommandParameter="{Binding}"
                                 HeightRequest="40"
                                 WidthRequest="70"
-                                BackgroundColor="#147efb"
+                                BackgroundColor="#4a69ff"
                                 Clicked="EditButton_Clicked"
                                 TextColor="#FFFFFF"
                                 FontAttributes="Bold"
                                 FontSize="14"
                                 CornerRadius="5"
                                 BorderWidth="2"
-                                BorderColor="#147efb" />
+                                BorderColor="#4a69ff" />
                         <Button Text="Delete"
                                 CommandParameter="{Binding Id}"
                                 HeightRequest="40"

--- a/DreamInventory/Views/Defendant/DefendantsPage.xaml
+++ b/DreamInventory/Views/Defendant/DefendantsPage.xaml
@@ -28,7 +28,7 @@
             </Grid>
 
             <StackLayout Grid.Row="1" x:Name="DesktopDefendantsList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
+                <Frame BackgroundColor="#4a69ff" Padding="0" Margin="0,20,0,10" HasShadow="False">
                     <Grid HeightRequest="40">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
@@ -87,7 +87,7 @@
             </StackLayout>
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobileDefendantsList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
+                <Frame BackgroundColor="#4a69ff" Padding="0" Margin="0,20,0,10" HasShadow="False">
                     <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">

--- a/DreamInventory/Views/Plaintiff/PlaintiffsPage.xaml
+++ b/DreamInventory/Views/Plaintiff/PlaintiffsPage.xaml
@@ -28,7 +28,7 @@
             </Grid>
 
             <StackLayout Grid.Row="1" x:Name="DesktopPlaintiffsList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
+                <Frame BackgroundColor="#4a69ff" Padding="0" Margin="0,20,0,10" HasShadow="False">
                     <Grid HeightRequest="40">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">
@@ -87,7 +87,7 @@
             </StackLayout>
 
             <StackLayout Grid.Row="1" Padding="0" x:Name="MobilePlaintiffsList">
-                <Frame BackgroundColor="#147efb" Padding="0" Margin="0,20,0,10" HasShadow="False">
+                <Frame BackgroundColor="#4a69ff" Padding="0" Margin="0,20,0,10" HasShadow="False">
                     <Grid HeightRequest="70">
                         <Grid.Margin>
                             <OnPlatform x:TypeArguments="Thickness">


### PR DESCRIPTION
UI changes:
 - Alternate rows color styles in Cases Listing pages for both MacOS and iOS
 - Added cancel button for NewCases page and EditCases page for both MacOS and iOS
 - Added position and styles for bottom MacOS Page Number Nav
 - Changed menu bar color styles for MacOS
 - Changed primary color scheme for application.


**DESKTOP**

![image](https://user-images.githubusercontent.com/19545625/77738630-32bccb80-7036-11ea-9147-6118c6f57725.png)

![image](https://user-images.githubusercontent.com/19545625/77738666-436d4180-7036-11ea-854f-5d635ddad0e9.png)

![image](https://user-images.githubusercontent.com/19545625/77738700-4f590380-7036-11ea-8aac-fa6382a86065.png)



**MOBILE**

![image](https://user-images.githubusercontent.com/19545625/77738832-84655600-7036-11ea-9b3a-d3a27e229da5.png)

![image](https://user-images.githubusercontent.com/19545625/77738897-a5c64200-7036-11ea-862f-0dd15f469e73.png)

![image](https://user-images.githubusercontent.com/19545625/77738924-af4faa00-7036-11ea-9678-742c9571da2f.png)
